### PR TITLE
fix: suppress PHP 8.1 deprecation warning

### DIFF
--- a/src/Soap.php
+++ b/src/Soap.php
@@ -34,6 +34,7 @@ class Soap extends \SoapClient
         parent::__construct($wsdl, $options);
     }
 
+    #[ReturnTypeWillChange]
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
         if (null !== $this->soapResponse) {


### PR DESCRIPTION
following deprecation is thrown when used in PHP 8.1

```php
Deprecated: Return type of Meng\Soap\Soap::__doRequest($request, $location, $action, $version, $one_way = 0) should either be compatible with SoapClient::__doRequest(string $request, string $location, string $action, int $version, bool $oneWay = false): ?string, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /vendor/meng-tian/php-soap-interpreter/src/Soap.php on line 37
```

Using an attribute to supress this warning should be backwards compatible with older PHP versions as well, since it will be parsed as a regular comment