### PR TITLE
Add return types for Interpreter and Soap

### DIFF
--- a/src/Interpreter.php
+++ b/src/Interpreter.php
@@ -29,7 +29,7 @@ class Interpreter
      * @param mixed  $input_headers     An array of headers to be interpreted along with the SOAP request.
      * @return SoapRequest
      */
-    public function request($function_name, array $arguments = [], array $options = null, $input_headers = null)
+    public function request($function_name, array $arguments = [], array $options = null, $input_headers = null):  SoapRequest
     {
         return $this->soap->request($function_name, $arguments, $options, $input_headers);
     }

--- a/src/Soap.php
+++ b/src/Soap.php
@@ -34,7 +34,7 @@ class Soap extends \SoapClient
         parent::__construct($wsdl, $options);
     }
 
-    public function __doRequest($request, $location, $action, $version, $one_way = 0)
+    public function __doRequest($request, $location, $action, $version, $one_way = 0): ?string
     {
         if (null !== $this->soapResponse) {
             return $this->soapResponse;
@@ -47,7 +47,7 @@ class Soap extends \SoapClient
         return '';
     }
 
-    public function request($function_name, $arguments, $options, $input_headers)
+    public function request($function_name, $arguments, $options, $input_headers): SoapRequest
     {
         $this->__soapCall($function_name, $arguments, $options, $input_headers);
         return new SoapRequest($this->endpoint, $this->soapAction, $this->soapVersion, $this->soapRequest);


### PR DESCRIPTION
PHP 7.0 or newer allows specify return types for methods.